### PR TITLE
Removed tab control in command input

### DIFF
--- a/app/renderer/components/task_input.js
+++ b/app/renderer/components/task_input.js
@@ -63,18 +63,6 @@ module.exports = {
                     Material.updateInput();
                 });
             }
-        },
-        onCommandTabPressed(ev) {
-            ev.preventDefault();
-            const target = ev.target;
-            const selection = target.selectionStart;
-
-            let value = this.command;
-            this.command = target.value = value.substring(0, selection) +
-                "    " +
-                value.substring(selection, value.length);
-
-            target.selectionStart = target.selectionEnd = selection + 4;
         }
     },
     computed: {

--- a/package.json
+++ b/package.json
@@ -20,9 +20,9 @@
     "mocha": "^3.2.0",
     "sinon": "^4.0.0"
   },
-  "config":{
-      "ignore": "(coverage|\\.travis.yml|\\.gitignore|test|\\.jshintrc)",
-      "icon": "resources/icon.png"
+  "config": {
+    "ignore": "(coverage|\\.travis.yml|\\.gitignore|test|\\.jshintrc)",
+    "icon": "resources/icon.png"
   },
   "scripts": {
     "test": "npm run clean && istanbul cover _mocha && npm run jshint",


### PR DESCRIPTION
## Description of the PR
Removed the code in task_input.js that prevented tab navigation when editing the command field.
I don't think a changelog edit or test addition is necessary for this small PR, but let me know if you would like one. All tests are still passing and I was testing the tab functionality and it was able to tab navigate out of the command field during edit mode. 

### Issues Related
issue #177 

------

Please, before doing the PR make sure that you are following the intructions described in [CONTRIBUTING.md](https://github.com/angrykoala/gaucho/blob/master/CONTRIBUTING.md) and you have completed the following checklist

**Checklist**
- [x ] Your PR is done against the `dev` branch
- [x ] Your origin branch is updated with the latest changes from `dev`
- [x ] All the tests and jshint are passing (`npm run test`)
- [ ] Changelog is updated with a brief description of your changes (if required)
- [ ] Your changes have tests

Thanks for contributing to Gaucho
