### PR TITLE
Minor cleanup and refactoring

### DIFF
--- a/app/common/app_config.js
+++ b/app/common/app_config.js
@@ -3,6 +3,12 @@
 const Store = require('electron-store');
 const utils = require('./utils');
 
+const FIELDS = {
+    WINDOW_SIZE: "windowSize",
+    DEVTOOLS_SIZE: "devToolsSize",
+    MAXIMIZED: "maximized",
+};
+
 const defaultUserConfig = {
     windowSize: [500, 600],
     devToolsSize: 300,
@@ -75,6 +81,7 @@ class TasksConfig extends AppConfig {
 }
 
 module.exports = {
+    FIELDS,
     User: UserConfig,
     Tasks: TasksConfig
 };

--- a/app/main/main_window.js
+++ b/app/main/main_window.js
@@ -27,7 +27,7 @@ module.exports = class MainWindow {
 
     initWindow(devWindow) {
         let win;
-        const windowSize = this.userConfig.get("windowSize");
+        const windowSize = this.userConfig.get(AppConfig.FIELDS.WINDOW_SIZE);
 
         let winConfig = {
             width: windowSize[0],
@@ -40,7 +40,7 @@ module.exports = class MainWindow {
             frame: true
         };
         if (devWindow) {
-            winConfig.width += this.userConfig.get("devToolsSize");
+            winConfig.width += this.userConfig.get(AppConfig.FIELDS.DEVTOOLS_SIZE);
         }
 
         win = new BrowserWindow(winConfig);
@@ -50,24 +50,24 @@ module.exports = class MainWindow {
 
         if (devWindow) win.webContents.openDevTools();
 
-        if (this.userConfig.get("maximized") === true) {
+        if (this.userConfig.get(AppConfig.FIELDS.MAXIMIZED) === true) {
             win.maximize();
         }
 
         win.on('resize', () => {
-            if (this.userConfig.get("maximized") !== true) {
+            if (this.userConfig.get(AppConfig.FIELDS.MAXIMIZED) !== true) {
                 let size = win.getSize();
-                if (devWindow) size[0] -= this.userConfig.get("devToolsSize");
-                this.userConfig.set("windowSize", size);
+                if (devWindow) size[0] -= this.userConfig.get(AppConfig.FIELDS.DEVTOOLS_SIZE);
+                this.userConfig.set(AppConfig.FIELDS.WINDOW_SIZE, size);
             }
         });
 
         win.on('maximize', () => {
-            this.userConfig.set("maximized", true);
+            this.userConfig.set(AppConfig.FIELDS.MAXIMIZED, true);
         });
 
         win.on('unmaximize', () => {
-            this.userConfig.set("maximized", false);
+            this.userConfig.set(AppConfig.FIELDS.MAXIMIZED, false);
         });
 
         let first = true;

--- a/app/renderer/suite.js
+++ b/app/renderer/suite.js
@@ -11,7 +11,7 @@ class Suite {
     }
 
     addTask(task) {
-        let title = this.getValidName(task.title);
+        const title = this.getValidName(task.title);
         task.title = title;
         this.tasks.push(task);
     }
@@ -22,7 +22,7 @@ class Suite {
 
     replaceTask(index, task) {
         if (this.tasks[index].title !== task.title) {
-            let title = this.getValidName(task.title);
+            const title = this.getValidName(task.title);
             task.title = title;
         }
         this.tasks.splice(index, 1, task);
@@ -43,7 +43,7 @@ class Suite {
     }
 
     runAll() {
-        for (const task of this.tasks) {
+        for (let task of this.tasks) {
             if (!task.isRunning()) task.run();
         }
     }
@@ -58,16 +58,15 @@ class Suite {
     getValidName(name) {
         let index = 2;
         if (!this.existTaskName(name)) return name;
-        while (this.existTaskName(`${name  } (${  index  })`)) {
+        while (this.existTaskName(`${name} (${index})`)) {
             index++;
         }
-        return `${name  } (${  index  })`;
+        return `${name} (${index})`;
     }
 
     existTaskName(name) {
         name = name.trim();
-        let index = this.tasks.find((task) => task.title === name);
-        return index !== undefined;
+        return this.tasks.find(task => task.title === name) !== undefined;
     }
 }
 

--- a/main.js
+++ b/main.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const path = require('path');
+const url = require('url');
 
 const MainWindow = require('./app/main/main_window');
 const AppEvents = require('./app/main/app_events');
@@ -13,7 +14,10 @@ function initApp() {
     function createWindow() {
         if (win === null) {
             const iconPath = path.join(__dirname, 'resources', 'icon.png');
-            const htmlUrl = `file://${__dirname}/index.html`;
+            const htmlUrl = url.format({
+                pathname: path.join(__dirname, 'index.html'),
+                protocol: 'file:'
+            });
 
             win = new MainWindow()
                 .setIcon(iconPath)


### PR DESCRIPTION
## Description of the PR

### This PR has following changes:

**Changes proposed in #186 are as follows:**

- ~Instead of extracting string concatenation to a variable at [`app/renderer/suite.js#L63`](https://github.com/angrykoala/gaucho/blob/master/app/renderer/suite.js#L63), it converts concatenation to ES6 template string~ This is already updated on `dev` and is appropriate choice here instead of extracting to variable, so I've just removed unnecessary whitespace.
- Uses `url` module to construct `htmlUrl` used in [`main.js#L20`](https://github.com/angrykoala/gaucho/blob/master/main.js#L20)
- Usage of `let` instead of `const` at [`app/renderer/suite.js#L61`](https://github.com/angrykoala/gaucho/blob/master/app/renderer/suite.js#L61) is appropriate as we're modifying `index` instead `while` loop.

**Additional improvements:**

- Adds constant config object in `app/main/main_window.js` to replace direct string usages of `windowSize`, `devToolsSize` & `maximized` at multiple places.
  - Reason is that hard-coding strings in multiple places is generally prone to typos as updating such string would require to update multiple places.
- Converts `let` to `const` in `app/renderer/suite.js` in multiple places where const is appropriate instead of let.

### Issues Related

Fixes #186 