### PR TITLE
log should auto scroll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 0.4.0 / ####-##-##
 ==================
-
+  * Auto scroll working on logs
   * Tasks can now be reordered within a suite while in edit mode
   * Added an initial message, noting the edit button to new users
   * Tasks with no path defined will now be executed on user home directory

--- a/app/renderer/components/task_card.js
+++ b/app/renderer/components/task_card.js
@@ -26,7 +26,7 @@ module.exports = {
     },
     template: `
     <li class="run-card task-card">
-        <div class="collapsible-header row unselectable-text">
+        <div class="collapsible-header row unselectable-text" v-on:click="autoScroll">
 
 
             <div class="col s1" v-if="AppStatus.editMode">
@@ -111,9 +111,9 @@ module.exports = {
         autoScroll() {
             let container = this.$el.querySelector(".run-output");
             if (container && container.scrollTop === container.scrollHeight - container.clientHeight) {
-                this.$nextTick(() => {
+                setTimeout(() => {
                     container.scrollTop = container.scrollHeight;
-                });
+                }, 0);  // don't scroll till next event loop
             }
         },
         collapseTask() {


### PR DESCRIPTION
## Description of the PR

The problem was that when autoScroll ran from the print function, it didn't have any affect if the log wasn't open. So, I added an event listener for when the body opens so that we can scroll for the user on that event as well. During development I found that the next dom update ($nextTick) was firing to soon for us to change the scroll on the div (collapsible.js wasn't done running). So, I swapped out to next javascript event loop (setTimeout 0) and it started working.

Not sure if setTimeout is really the right way to go here or if there is just something about vue that I'm missing. Anyways, this fixes the bug I think.

### Issues Related
#55 

------

Please, before doing the PR make sure that you are following the intructions described in [CONTRIBUTING.md](https://github.com/angrykoala/gaucho/blob/master/CONTRIBUTING.md) and you have completed the following checklist

**Checklist**
- [x] Your PR is done against the `dev` branch
- [x] Your origin branch is updated with the latest changes from `dev`
- [x] All the tests and jshint are passing (`npm run test`)
- [x] Changelog is updated with a brief description of your changes (if required)
- [ ] Your changes have tests

Thanks for contributing to Gaucho
