### PR TITLE
Change alert message when importing tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
   * Added a dev config environment
   * Code refactoring in several components and modules
   * Code linting rules changed, using eslint instead of jshint
-  * Wrote more descriptive and appropriate alert messages and button text
+  * Wrote more descriptive and appropriate alert messages
 
 0.3.0 / 2017-08-29
 ==================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
   * Added a dev config environment
   * Code refactoring in several components and modules
   * Code linting rules changed, using eslint instead of jshint
+  * Wrote more descriptive and appropriate alert messages and button text
 
 0.3.0 / 2017-08-29
 ==================

--- a/app/renderer/components/config_menu.js
+++ b/app/renderer/components/config_menu.js
@@ -60,7 +60,7 @@ module.exports = {
             }, (filenames) => {
                 if (filenames && filenames[0]) {
                     const filename = filenames[0];
-                    const confirmationAlert = new DeleteConfirmationAlert("Importing tasks will remove all current tasks. Are you sure you want to continue?",
+                    const confirmationAlert = new DeleteConfirmationAlert("Importing tasks will remove all current tasks.",
                          {confirmButtonText: "Yes, import tasks", cancelButtonText: "No, cancel import"});
                     confirmationAlert.toggle().then(() => {
                         TasksHandler.clearTasks();
@@ -86,7 +86,8 @@ module.exports = {
             });
         },
         clearTasks() {
-            const confirmationAlert = new DeleteConfirmationAlert("You will not be able to recover these tasks after deletion!");
+            const confirmationAlert = new DeleteConfirmationAlert("You will not be able to recover these tasks after deletion!",
+                {confirmButtonText: "Yes, clear them!", cancelButtonText: "No, keep them"});
             confirmationAlert.toggle().then(() => {
                 TasksHandler.clearTasks();
                 TasksHandler.addDefaultSuite()

--- a/app/renderer/components/config_menu.js
+++ b/app/renderer/components/config_menu.js
@@ -60,7 +60,8 @@ module.exports = {
             }, (filenames) => {
                 if (filenames && filenames[0]) {
                     const filename = filenames[0];
-                    const confirmationAlert = new DeleteConfirmationAlert("You will not be able to recover this task after deletion!");
+                    const confirmationAlert = new DeleteConfirmationAlert("Importing tasks will remove all current tasks. Are you sure you want to continue?",
+                         {confirmButtonText: "Yes, import tasks", cancelButtonText: "No, cancel import"});
                     confirmationAlert.toggle().then(() => {
                         TasksHandler.clearTasks();
                         fs.readFile(filename, 'utf-8', (err, data) => {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "eslint-config-vue": "^2.0.2",
     "eslint-plugin-vue": "^3.13.1",
     "istanbul": "^0.4.5",
-    "just-extend": "^1.1.22",
     "mocha": "^3.2.0",
     "pre-commit": "^1.2.2",
     "sinon": "^4.0.1"

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "eslint-config-vue": "^2.0.2",
     "eslint-plugin-vue": "^3.13.1",
     "istanbul": "^0.4.5",
+    "just-extend": "^1.1.22",
     "mocha": "^3.2.0",
     "pre-commit": "^1.2.2",
     "sinon": "^4.0.1"


### PR DESCRIPTION
## Description of the PR

This PR creates more detailed alerts and button text on clearing and importing tasks. It also added an explicit version of just-extend to package.json due to a [breaking change](https://github.com/angrykoala/gaucho/issues/210), and then removed this explicit version when a fix to just-extend was implemented.

### Issues Related

https://github.com/angrykoala/gaucho/issues/209
https://github.com/angrykoala/gaucho/issues/210

------

**Checklist**
- [x] Your PR is done against the `dev` branch
- [x] Your origin branch is updated with the latest changes from `dev`
- [x] All the tests and jshint are passing (`npm run test`)
- [x] Changelog is updated with a brief description of your changes (if required)
- [ ] Your changes have tests