### PR TITLE
Link down the page to dev instructions in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Available versions for Linux, Mac and Windows (64 bits).
 
 To use, unzip in the desired location and execute gaucho (execute file depends on you OS).
 
-If you need a different version, please, follow the _development_ instructions to make your own build from the source code
+If you need a different version, please, follow the [development instructions](#development) to make your own build from the source code
 
 ## Usage
 Gaucho allows you to configure _tasks_ as part of different _suites_ or groups you can access the different suites by clicking on its name in the navbar menu.


### PR DESCRIPTION
## Description of the PR
Found my self wanting to look at CONTRIBUTING.md when "development instructions" were mentioned in the readme because I had seen that file link go by already and the "Development" section of the readme was still below the fold. I thought a link down the page might add clarity but feel free to ignore this if you don't agree.

### Issues Related
none