### PR TITLE
Issue #244 change task name to valid name after moving to new suite

### DIFF
--- a/app/renderer/components/task_suite.js
+++ b/app/renderer/components/task_suite.js
@@ -37,6 +37,7 @@ module.exports = {
             data-collapsible="accordion"
             v-model="suite.tasks"
             @start="onDragStart"
+            @add="onAdd"
             :move="checkMove">
                 <template v-for="(task,i) in suite.tasks">
                     <task-card v-bind:task="task" v-on:remove="removeTask(i)" @edit="editTask(i, $event)" v-bind:event="event"></task-card>
@@ -65,6 +66,10 @@ module.exports = {
         },
         onDragStart() {
             this.event.emit("collapseTask");
+        },
+        onAdd(evt){
+            let task = this.suite.tasks[evt.newIndex]
+            task.title = this.suite.getValidName(task.title)
         },
         addTask(task) {
             if (this.suite.length < AppStatus.maxTasksPerSuite) {


### PR DESCRIPTION
## Description of the PR
As per #244, I've added a callback for the draggable add event, which is only called when moving tasks from one suite to another. The moved task is renamed using the same naming logic as when they are added. 

### Issues Related
#244

------

Please, before doing the PR make sure that you are following the intructions described in [CONTRIBUTING.md](https://github.com/angrykoala/gaucho/blob/master/CONTRIBUTING.md) and you have completed the following checklist

**Checklist**
- [x] Your PR is done against the `dev` branch
- [x] Your origin branch is updated with the latest changes from `dev`
- [x] All the tests and jshint are passing (`npm run test`)
- [ ] Changelog is updated with a brief description of your changes (if required)
- [ ] Your changes have tests

Thanks for contributing to Gaucho
