### PR TITLE
Fixed dependency issues with Sortable.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "material-design-icons-iconfont": "^3.0.3",
     "materialize-css": "^0.99.0",
     "mousetrap": "^1.6.1",
+    "sortablejs": "RubaXa/Sortable#passive",
     "sweetalert2": "^6.11.1",
     "vue": "^2.0.8",
     "vuedraggable": "^2.14.1",


### PR DESCRIPTION
## Description of the PR
Changed `vuedraggable`'s `Sortable` dependency to the `passive` branch in order to get rid of the warning messages regarding `Sortable`'s `captureMode`.

### Issues Related
#196 