### PR TITLE
Remove eslint-config-vue node module

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "electron": "~1.7.8",
     "electron-builder": "^19.41.1",
     "eslint": "^4.8.0",
-    "eslint-config-vue": "^2.0.2",
     "eslint-plugin-vue": "^3.13.1",
     "istanbul": "^0.4.5",
     "mocha": "^4.0.0",


### PR DESCRIPTION
## Description of the PR
Remove eslint-config-vue node module, as it is unnecessary and causes npm to throw warning messages.

### Issues Related
#257 