### PR TITLE
Added ability to control amount of suites / tasks within limited range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ==================
 
   * It is possible to navigate the menu using tab
+  * Fixed bug where stderr was not being displayed
 
 0.4.0 / 2017-10-02
 ==================

--- a/app/common/app_config.js
+++ b/app/common/app_config.js
@@ -59,9 +59,11 @@ class AppConfig {
             encryptionKey: key
         });
     }
+
     set(key, value) {
         this.store.set(key, value);
     }
+
     get(key) {
         const result = this.store.get(key);
         return result;

--- a/app/common/suite.js
+++ b/app/common/suite.js
@@ -5,17 +5,21 @@ class Suite {
         this.title = title || "";
         this.tasks = [];
     }
+
     get length() {
         return this.tasks.length;
     }
+
     addTask(task) {
         const title = this.getValidName(task.title);
         task.title = title;
         this.tasks.push(task);
     }
+
     removeTask(index) {
         this.tasks.splice(index, 1);
     }
+
     replaceTask(index, task) {
         if (this.tasks[index].title !== task.title) {
             const title = this.getValidName(task.title);
@@ -23,6 +27,7 @@ class Suite {
         }
         this.tasks.splice(index, 1, task);
     }
+
     stopAll() {
         const promises = this.tasks.map((task) => {
             if (!task.isRunning()) return Promise.resolve();
@@ -36,17 +41,20 @@ class Suite {
         });
         return Promise.all(promises);
     }
+
     runAll() {
         for (let task of this.tasks) {
             if (!task.isRunning()) task.run();
         }
     }
+
     getData() {
         return {
             title: this.title,
             tasks: this.tasks.map((task) => task.getData())
         };
     }
+
     getValidName(name) {
         let index = 2;
         if (!this.existTaskName(name)) return name;
@@ -55,6 +63,7 @@ class Suite {
         }
         return `${name} (${index})`;
     }
+
     existTaskName(name) {
         name = name.trim();
         return this.tasks.find(task => task.title === name) !== undefined;

--- a/app/common/task.js
+++ b/app/common/task.js
@@ -24,6 +24,7 @@ class Task {
         this.elapsedTime = null;
         this.onTimeUpdate = null;
     }
+
     run(stdout, done) {
         if (this.isRunning()) {
             throw new Error("Trying to run task without stopping it first");
@@ -56,15 +57,18 @@ class Task {
         TaskEvents.on("time-update", this.onTimeUpdate);
         this._updateElapsedTime();
     }
+
     stop(cb) {
         if (this.isRunning()) {
             yerbamate.stop(this.proc, cb);
             this.status = TaskStatus.stopped;
         } else if (cb) cb();
     }
+
     isRunning() {
         return this.status === TaskStatus.running;
     }
+
     getData() {
         let res = {
             title: this.title,
@@ -73,6 +77,7 @@ class Task {
         if (this.path !== "") res.path = this.path;
         return res;
     }
+
     _updateElapsedTime() {
         if (this.beginTime === null) throw new Error("Error, cant update time");
         let finishTime = this.finishTime;
@@ -80,9 +85,11 @@ class Task {
 
         this.elapsedTime = Math.trunc((finishTime - this.beginTime) / 1000);
     }
+
     _processCommand() {
         return this.command.replace(/(^|\s)sudo($|\s)/g, "$1pkexec$2");
     }
+
     _generateDefaultPath() {
         return os.homedir();
     }

--- a/app/common/task.js
+++ b/app/common/task.js
@@ -35,13 +35,14 @@ class Task {
         this.finishTime = null;
         let executionPath = this.path;
         if (!executionPath) executionPath = this._generateDefaultPath();
+        const onOutput=(out)=>{
+            this.output += `\n${out}`;
+            this.output = this.output.slice(-outputMaxSize).trim();
+            stdout(this.output);
+        }
         this.proc = yerbamate.run(this._processCommand(), executionPath, {
-            stderr: stdout,
-            stdout: (out) => {
-                this.output += `\n${out}`;
-                this.output = this.output.slice(-outputMaxSize).trim();
-                stdout(this.output);
-            }
+            stderr: onOutput,
+            stdout: onOutput
         },
         (code) => {
             if (this.status !== TaskStatus.stopped) this.status = yerbamate.successCode(code) ? TaskStatus.ok : TaskStatus.error;

--- a/app/main/main_window.js
+++ b/app/main/main_window.js
@@ -13,14 +13,17 @@ module.exports = class MainWindow {
         this.indexPath = null;
         this.userConfig = new AppConfig.User();
     }
+
     setIcon(path) {
         this.iconPath = path;
         return this;
     }
+
     setIndex(htmlFile) {
         this.indexPath = htmlFile;
         return this;
     }
+
     initWindow(devWindow) {
         let win;
         const windowSize = this.userConfig.get(AppConfig.FIELDS.WINDOW_SIZE);

--- a/app/renderer/api/app_alerts.js
+++ b/app/renderer/api/app_alerts.js
@@ -8,10 +8,12 @@ class AppAlert {
             title: title
         }, options);
     }
+
     html(html) {
         this.alertOptions.html = html;
         return this;
     }
+
     toggle() {
         return swal(this.alertOptions);
     }

--- a/app/renderer/api/gaucho_actions.js
+++ b/app/renderer/api/gaucho_actions.js
@@ -8,6 +8,7 @@ module.exports = class GauchoActions {
         AppStatus.editMode = !AppStatus.editMode;
         TasksHandler.saveTasks();
     }
+
     static toggleActiveSuite(suite) {
         AppStatus.activeSuite = suite;
     }

--- a/app/renderer/app_config_status.js
+++ b/app/renderer/app_config_status.js
@@ -9,24 +9,30 @@ module.exports = class AppConfigStatus {
         this._animatedSpinner = this.appConfig.get("animatedSpinner");
         this._showTimer = this.appConfig.get("showTimer");
     }
+
     set bottomBar(value) {
         this._bottomBar = value;
         this.appConfig.set("bottomBar", value);
     }
+
     set animatedSpinner(value) {
         this._animatedSpinner = value;
         this.appConfig.set("animatedSpinner", value);
     }
+
     set showTimer(value) {
         this._showTimer = value;
         this.appConfig.set("showTimer", value);
     }
+
     get bottomBar() {
         return this._bottomBar;
     }
+
     get animatedSpinner() {
         return this._animatedSpinner;
     }
+
     get showTimer() {
         return this._showTimer;
     }

--- a/app/renderer/app_config_status.js
+++ b/app/renderer/app_config_status.js
@@ -26,14 +26,17 @@ module.exports = class AppConfigStatus {
         this._showTimer = value;
         this.appConfig.set("showTimer", value);
     }
+
     set maxSuites(value) {
         this._maxSuites = value;
         this.appConfig.set("maxSuites", value);
     }
+
     set maxTasksPerSuite(value) {
         this._maxTasksPerSuite = value;
         this.appConfig.set("maxTasksPerSuite", value);
     }
+
     get bottomBar() {
         return this._bottomBar;
     }
@@ -45,9 +48,11 @@ module.exports = class AppConfigStatus {
     get showTimer() {
         return this._showTimer;
     }
+
     get maxSuites() {
         return this._maxSuites;
     }
+
     get maxTasksPerSuite() {
         return this._maxTasksPerSuite;
     }

--- a/app/renderer/tasks_handler.js
+++ b/app/renderer/tasks_handler.js
@@ -9,9 +9,11 @@ class TasksHandler {
     get suites() {
         return suites;
     }
+
     addSuite(suite) {
         suites.push(suite);
     }
+
     loadTasksFromConfig() {
         const tasksConfig = new AppConfig.Tasks();
         let suites = tasksConfig.get("suites");
@@ -24,10 +26,12 @@ class TasksHandler {
         }
         this._loadTasks(suites);
     }
+
     loadTasksFromData(data) {
         this._loadTasks(data.suites);
         this.saveTasks();
     }
+
     _loadTasks(suites){
         this.clearTasks();
         const loadedSuites = this._parseData(suites);
@@ -35,6 +39,7 @@ class TasksHandler {
             this.addSuite(suite);
         });
     }
+
     saveTasks() {
         const tasksConfig = new AppConfig.Tasks();
         const data = this.suites.map((suite) => suite.getData());
@@ -43,19 +48,23 @@ class TasksHandler {
             tasksConfig.set("suites", data);
         }
     }
+
     addDefaultSuite() {
         suites.push(new Suite("Suite 1"));
         this.saveTasks();
     }
+
     clearTasks() {
         for (const suite of this.suites) {
             suite.stopAll();
         }
         this.suites.splice(0, this.suites.length);
     }
+
     _isValid(data) {
         return (Array.isArray(data) && data.length >= 1);
     }
+
     _parseData(data) {
         return data.map((suite) => {
             let result = new Suite(suite.title);

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "main.js",
   "dependencies": {
     "electron-store": "^1.3.0",
-    "jquery-ui": "^1.12.1",
     "jquery": "^3.1.1",
+    "jquery-ui": "^1.12.1",
     "material-design-icons-iconfont": "^3.0.3",
     "materialize-css": "^0.99.0",
     "mousetrap": "^1.6.1",
@@ -20,6 +20,7 @@
     "cross-env": "^5.0.5",
     "electron": "~1.7.8",
     "electron-builder": "^19.41.1",
+    "electron-prebuilt": "^1.4.13",
     "eslint": "^4.8.0",
     "eslint-plugin-vue": "^3.13.1",
     "istanbul": "^0.4.5",
@@ -33,7 +34,7 @@
     "icon": "resources/icon.png"
   },
   "scripts": {
-    "test": "istanbul cover _mocha -- --exit && npm run lint",
+    "test": "istanbul cover node_modules/mocha/bin/_mocha -- --exit && npm run lint",
     "start": "electron .",
     "start-dev": "cross-env NODE_ENV=dev npm start",
     "clean": "rm -rf config.json tasks.json coverage dist",

--- a/test/front-end.test.js
+++ b/test/front-end.test.js
@@ -1,12 +1,21 @@
 const Application = require('spectron').Application;
 const assert = require('assert');
 
+// Handle testing in Windows environments
+const appPath = (() => {
+    if(process.platform === 'win32') {
+        return './node_modules/electron-prebuilt/dist/electron.exe'
+    } else {
+        return './node_modules/.bin/electron'
+    }
+})();
+
 describe('Front-end tests', function () {
     this.timeout(20000); // needed for Travis builds
 
     beforeEach(() => {
         this.app = new Application({
-            path: './node_modules/.bin/electron',
+            path: appPath,
             args: ['main.js'],
             startTimeout: 20000 // timeout for ChromeDriver start
         });


### PR DESCRIPTION
## Description of the PR
This feature grants users the ability to control the maximum amount of suites and tasks per suite within a controlled range. The original limit was 6 for suites and 8 for tasks which remain the default in this feature, maximums stopping at 12 for suites and 20 for tasks.

Additionally, made some changes to the front-end testing / package.json to support testing in a Windows environment. This will need to be tested in Mac / Linux environments. As for tests, it appears that the whole configuration menu needs tests written which I am happy to add in another pull request (or this one if required).

### Issues Related
[Add New Task Missing After 8 Tasks](https://github.com/angrykoala/gaucho/issues/265)

------

Please, before doing the PR make sure that you are following the intructions described in [CONTRIBUTING.md](https://github.com/angrykoala/gaucho/blob/master/CONTRIBUTING.md) and you have completed the following checklist

**Checklist**
- [x] Your PR is done against the `dev` branch
- [x] Your origin branch is updated with the latest changes from `dev`
- [x] All the tests and linters are passing (`npm run test`)
- [ ] Your changes have tests

Thanks for contributing to Gaucho
