### PR TITLE
Move "check for updates" config to separated section

### DIFF
--- a/src/app/components/settings/settings_menu.vue
+++ b/src/app/components/settings/settings_menu.vue
@@ -20,6 +20,16 @@
 
                 <hr>
 
+                <settings-section title="Other" :collapsable="false">
+                    <h2 class="settings-current-version">
+                        <strong>Gaucho</strong> - Version {{currentVersion}}
+                    </h2>
+
+                    <checkbox-item v-model="checkUpdates" label="Check for updates"></checkbox-item>
+                </settings-section>
+
+                <hr>
+
                 <settings-section title="Actions" :collapsable="false">
                     <settings-actions @resetSettings="resetSettings"></settings-actions>
                 </settings-section>
@@ -30,14 +40,6 @@
 
                 <settings-section title="Shortcuts" :collapsable="true">
                     <shortcuts-cheatsheet></shortcuts-cheatsheet>
-                </settings-section>
-
-                <settings-section title="About" :collapsable="true">
-                    <h2 class="settings-current-version">
-                        <strong>Gaucho</strong> - Version {{currentVersion}}
-                    </h2>
-
-                    <checkbox-item v-model="checkUpdates" label="Check for updates"></checkbox-item>
                 </settings-section>
             </div>
         </div>


### PR DESCRIPTION
## Description of the PR
Created an "About" section inside settings menu that, for now, includes the checkbox for "Check for updates" config. It was slightly based on "About" section in Google Chrome settings page.

**Results:**

![Screenshot from 2021-10-15 18-03-15](https://user-images.githubusercontent.com/6589691/137553286-9f33de38-c464-4def-a84f-413cdf1211e4.png)

### Issues Related
#426 

------

Please, before doing the PR make sure that you are following the intructions described in [CONTRIBUTING.md](https://github.com/angrykoala/gaucho/blob/master/CONTRIBUTING.md) and you have completed the following checklist

**Checklist**
- [x] Your PR is done against the `dev` branch
- [x] Your origin branch is updated with the latest changes from `dev`
- [x] All the tests and linters are passing (`npm run test`)
- [ ] Your changes have tests

Thanks for contributing to Gaucho
